### PR TITLE
Add cube flop example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ int entry(int argc, char **argv) {
 6. Run build/cgame.exe
 7. profit
 
+### Linux Quickstart
+1. Run `./install_deps.sh` to install the required cross compiler and Wine
+2. Build and run the example with `./run.sh`
+
+
 ## Examples & Documentation
 
 In general, we try to leave a nice chunk of documentation in a comment at the top of the source code files when needed.

--- a/build.c
+++ b/build.c
@@ -50,7 +50,7 @@ typedef struct Context_Extra {
 // #include "oogabooga/examples/window_test.c"
 // #include "oogabooga/examples/offscreen_drawing.c"
 // #include "oogabooga/examples/threaded_drawing.c"
-#include "oogabooga/examples/bloom.c"
+#include "entry_cube_flop.c"
 
 // These examples require some extensions to be enabled. See top respective files for more info.
 // #include "oogabooga/examples/particles_example.c" // Requires OOGABOOGA_EXTENSION_PARTICLES

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 CC=x86_64-w64-mingw32-gcc
-CFLAGS="-g -O0 -std=c11 --static -D_CRT_SECURE_NO_WARNINGS
-        -Wextra -Wno-sign-compare -Wno-unused-parameter
-        -lkernel32 -lgdi32 -luser32 -lruntimeobject
-        -lwinmm -ld3d11 -ldxguid -ld3dcompiler 
-        -lshlwapi -lole32 -lavrt -lksuser -ldbghelp
+CFLAGS="-g -O0 -std=c11 --static -D_CRT_SECURE_NO_WARNINGS \
+        -Wextra -Wno-sign-compare -Wno-unused-parameter \
+        -lkernel32 -lgdi32 -luser32 -lruntimeobject \
+        -lwinmm -ld3d11 -ldxguid -ld3dcompiler \
+        -lshlwapi -lole32 -lavrt -lksuser -ldbghelp \
         -lshcore"
 SRC=../build.c
 EXENAME=game.exe
 
 mkdir -p build
 cd build
-$CC $SRC -o $EXENAME $CFLAGS
+$CC $SRC -o $EXENAME $CFLAGS "$@"
 cd ..

--- a/entry_cube_flop.c
+++ b/entry_cube_flop.c
@@ -1,0 +1,174 @@
+// Simple 3D cube flop game example
+
+#define CELL_SIZE 1.0f
+#define BOARD_SIZE 5
+
+typedef struct {
+    int x;
+    int y;
+} Grid_Pos;
+
+static Grid_Pos cube_pos = {2, 2};
+static Grid_Pos hole_pos = {4, 1};
+
+static bool rotating = false;
+static float rotate_t = 0.0f;
+static Vector3f32 pivot_offset;
+static Vector3f32 rotate_axis;
+static Grid_Pos target_pos;
+
+Matrix4 make_cube_xform() {
+    float board_half = BOARD_SIZE * CELL_SIZE * 0.5f;
+    Vector3f32 pos = v3f32((cube_pos.x + 0.5f) * CELL_SIZE - board_half,
+                           CELL_SIZE * 0.5f,
+                           (cube_pos.y + 0.5f) * CELL_SIZE - board_half);
+
+    Matrix4 m = m4_scalar(1.0f);
+    m = m4_translate(m, pos);
+    if (rotating) {
+        m = m4_translate(m, pivot_offset);
+        m = m4_rotate(m, rotate_axis, rotate_t * PI32 * 0.5f);
+        m = m4_translate(m, v3_mulf(pivot_offset, -1.0f));
+    }
+    return m;
+}
+
+void draw_cube(Matrix4 transform, Vector4 color) {
+    Matrix4 face;
+    float s = CELL_SIZE;
+
+    // front
+    face = transform;
+    face = m4_translate(face, v3f32(-s/2, -s/2, s/2));
+    draw_rect_xform(face, v2(s, s), color);
+
+    // back
+    face = transform;
+    face = m4_rotate_y(face, PI32);
+    face = m4_translate(face, v3f32(-s/2, -s/2, s/2));
+    draw_rect_xform(face, v2(s, s), color);
+
+    // left
+    face = transform;
+    face = m4_rotate_y(face, -PI32*0.5f);
+    face = m4_translate(face, v3f32(-s/2, -s/2, s/2));
+    draw_rect_xform(face, v2(s, s), color);
+
+    // right
+    face = transform;
+    face = m4_rotate_y(face, PI32*0.5f);
+    face = m4_translate(face, v3f32(-s/2, -s/2, s/2));
+    draw_rect_xform(face, v2(s, s), color);
+
+    // top
+    face = transform;
+    face = m4_rotate_x(face, -PI32*0.5f);
+    face = m4_translate(face, v3f32(-s/2, -s/2, s/2));
+    draw_rect_xform(face, v2(s, s), color);
+
+    // bottom
+    face = transform;
+    face = m4_rotate_x(face, PI32*0.5f);
+    face = m4_translate(face, v3f32(-s/2, -s/2, s/2));
+    draw_rect_xform(face, v2(s, s), color);
+}
+
+Vector3f32 board_tile_world(int x, int y) {
+    float board_half = BOARD_SIZE * CELL_SIZE * 0.5f;
+    return v3f32((x + 0.5f) * CELL_SIZE - board_half, 0,
+                 (y + 0.5f) * CELL_SIZE - board_half);
+}
+
+int entry(int argc, char **argv) {
+    window.title = STR("Cube Flop");
+    window.point_width = 1280;
+    window.point_height = 720;
+    window.clear_color = v4(0.05f, 0.05f, 0.05f, 1.0f);
+
+    float cam_yaw = 0.5f;
+    float cam_pitch = 0.7f;
+    float cam_dist = 8.0f;
+
+    Vector2f32 last_mouse = v2f32(0, 0);
+
+    float64 last_time = os_get_elapsed_seconds();
+    while (!window.should_close) {
+        reset_temporary_storage();
+        float64 now = os_get_elapsed_seconds();
+        float dt = now - last_time;
+        last_time = now;
+
+        Vector2f32 mouse_delta = v2f32(input_frame.mouse_x - last_mouse.x,
+                                       input_frame.mouse_y - last_mouse.y);
+        last_mouse = v2f32(input_frame.mouse_x, input_frame.mouse_y);
+
+        if (is_key_down(MOUSE_BUTTON_LEFT)) {
+            cam_yaw   += mouse_delta.x * 0.005f;
+            cam_pitch += mouse_delta.y * 0.005f;
+            cam_pitch = clamp(cam_pitch, 0.2f, 1.2f);
+        }
+
+        if (!rotating) {
+            if (is_key_just_pressed('A')) {
+                target_pos = (Grid_Pos){cube_pos.x-1, cube_pos.y};
+                rotate_axis = v3f32(0,0,1);
+                pivot_offset = v3f32(-CELL_SIZE/2, -CELL_SIZE/2, 0);
+                rotating = true;
+            } else if (is_key_just_pressed('D')) {
+                target_pos = (Grid_Pos){cube_pos.x+1, cube_pos.y};
+                rotate_axis = v3f32(0,0,-1);
+                pivot_offset = v3f32(CELL_SIZE/2, -CELL_SIZE/2, 0);
+                rotating = true;
+            } else if (is_key_just_pressed('W')) {
+                target_pos = (Grid_Pos){cube_pos.x, cube_pos.y-1};
+                rotate_axis = v3f32(-1,0,0);
+                pivot_offset = v3f32(0, -CELL_SIZE/2, -CELL_SIZE/2);
+                rotating = true;
+            } else if (is_key_just_pressed('S')) {
+                target_pos = (Grid_Pos){cube_pos.x, cube_pos.y+1};
+                rotate_axis = v3f32(1,0,0);
+                pivot_offset = v3f32(0, -CELL_SIZE/2, CELL_SIZE/2);
+                rotating = true;
+            }
+        }
+
+        if (rotating) {
+            rotate_t += dt * 3.0f;
+            if (rotate_t >= 1.0f) {
+                cube_pos = target_pos;
+                rotating = false;
+                rotate_t = 0.0f;
+            }
+        }
+
+        float aspect = (float)window.width / (float)window.height;
+        draw_frame.projection = m4_make_perspective_projection(PI32/4.0f, aspect, 0.1f, 100.f);
+
+        Vector3f32 cam_pos = v3f32(sinf(cam_yaw)*cosf(cam_pitch)*cam_dist,
+                                  sinf(cam_pitch)*cam_dist,
+                                  cosf(cam_yaw)*cosf(cam_pitch)*cam_dist);
+        draw_frame.camera_xform = m4_make_look_at(cam_pos, v3f32(0,0,0), v3f32(0,1,0));
+
+        // draw board
+        for(int y=0;y<BOARD_SIZE;y++)
+        for(int x=0;x<BOARD_SIZE;x++) {
+            if (x==hole_pos.x && y==hole_pos.y) continue;
+            Matrix4 tile = m4_scalar(1.0f);
+            tile = m4_rotate_x(tile, -PI32*0.5f);
+            tile = m4_translate(tile, board_tile_world(x,y));
+            draw_rect_xform(tile, v2(CELL_SIZE, CELL_SIZE), v4(0.2f,0.2f,0.2f,1.0f));
+        }
+
+        // draw cube
+        Matrix4 cube = make_cube_xform();
+        draw_cube(cube, COLOR_GREEN);
+
+        if (!rotating && cube_pos.x==hole_pos.x && cube_pos.y==hole_pos.y) {
+            log("You Win!");
+        }
+
+        os_update();
+        gfx_update();
+    }
+    return 0;
+}

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Install required packages to build and run the example on Linux
+set -e
+sudo apt-get update
+sudo apt-get install -y gcc-mingw-w64-x86-64 wine

--- a/oogabooga/linmath.c
+++ b/oogabooga/linmath.c
@@ -676,6 +676,14 @@ inline Matrix4 m4_rotate_z(Matrix4 m, float32 radians) {
     Matrix4 rotation_matrix = m4_make_rotation(v3f32(0, 0, 1), radians);
     return m4_mul(m, rotation_matrix);
 }
+inline Matrix4 m4_rotate_x(Matrix4 m, float32 radians) {
+    Matrix4 rotation_matrix = m4_make_rotation(v3f32(1, 0, 0), radians);
+    return m4_mul(m, rotation_matrix);
+}
+inline Matrix4 m4_rotate_y(Matrix4 m, float32 radians) {
+    Matrix4 rotation_matrix = m4_make_rotation(v3f32(0, 1, 0), radians);
+    return m4_mul(m, rotation_matrix);
+}
 
 inline Matrix4 m4_scale(Matrix4 m, Vector3f32 scale) {
     Matrix4 scale_matrix = m4_make_scale(scale);
@@ -692,6 +700,30 @@ Matrix4 m4_make_orthographic_projection(float32 left, float32 right, float32 bot
     m.m[0][3] = -(right + left) / (right - left);
     m.m[1][3] = -(top + bottom) / (top - bottom);
     m.m[2][3] = -(_far + _near) / (_far - _near);
+    m.m[3][3] = 1.0f;
+    return m;
+}
+
+Matrix4 m4_make_perspective_projection(float32 fov_y, float32 aspect, float32 _near, float32 _far) {
+    Matrix4 m = ZERO(Matrix4);
+    float32 f = 1.0f / tanf(fov_y * 0.5f);
+    m.m[0][0] = f / aspect;
+    m.m[1][1] = f;
+    m.m[2][2] = (_far + _near) / (_near - _far);
+    m.m[2][3] = (2.0f * _far * _near) / (_near - _far);
+    m.m[3][2] = -1.0f;
+    return m;
+}
+
+Matrix4 m4_make_look_at(Vector3f32 eye, Vector3f32 target, Vector3f32 up) {
+    Vector3f32 f = v3_normalize(v3_sub(target, eye));
+    Vector3f32 s = v3_normalize(v3_cross(f, up));
+    Vector3f32 u = v3_cross(s, f);
+
+    Matrix4 m = m4_scalar(1.0f);
+    m.m[0][0] = s.x; m.m[0][1] = s.y; m.m[0][2] = s.z; m.m[0][3] = -v3_dot(s, eye);
+    m.m[1][0] = u.x; m.m[1][1] = u.y; m.m[1][2] = u.z; m.m[1][3] = -v3_dot(u, eye);
+    m.m[2][0] = -f.x; m.m[2][1] = -f.y; m.m[2][2] = -f.z; m.m[2][3] = v3_dot(f, eye);
     m.m[3][3] = 1.0f;
     return m;
 }

--- a/oogabooga/tests.c
+++ b/oogabooga/tests.c
@@ -1041,14 +1041,34 @@ void test_linmath() {
 	    assert(result_matrix.m[0][3] == 2.0f && result_matrix.m[1][3] == 4.0f && result_matrix.m[2][3] == 6.0f, "m4_mul incorrect");
 	
 	    // Test matrix inverse
-	    Matrix4 identity = m4_scalar(1.0f);
-	    Matrix4 inverse_matrix = m4_inverse(identity);
-	    for (int i = 0; i < 4; ++i) {
-	        for (int j = 0; j < 4; ++j) {
-	            assert(inverse_matrix.m[i][j] == identity.m[i][j], "m4_inverse incorrect for identity matrix");
-	        }
-	    }
-    }
+            Matrix4 identity = m4_scalar(1.0f);
+            Matrix4 inverse_matrix = m4_inverse(identity);
+            for (int i = 0; i < 4; ++i) {
+                for (int j = 0; j < 4; ++j) {
+                    assert(inverse_matrix.m[i][j] == identity.m[i][j], "m4_inverse incorrect for identity matrix");
+                }
+            }
+
+            // Test new rotation helpers
+            Matrix4 rot_x = m4_rotate_x(identity, PI32 * 0.5f);
+            assert(floats_roughly_match(rot_x.m[1][2], -1.0f) &&
+                   floats_roughly_match(rot_x.m[2][1], 1.0f),
+                   "m4_rotate_x incorrect");
+
+            Matrix4 rot_y = m4_rotate_y(identity, PI32 * 0.5f);
+            assert(floats_roughly_match(rot_y.m[0][2], 1.0f) &&
+                   floats_roughly_match(rot_y.m[2][0], -1.0f),
+                   "m4_rotate_y incorrect");
+
+            // Test perspective projection helper
+            Matrix4 persp = m4_make_perspective_projection(PI32/2.0f, 1.0f, 1.0f, 10.0f);
+            assert(floats_roughly_match(persp.m[0][0], persp.m[1][1]), "m4_make_perspective_projection aspect");
+            assert(floats_roughly_match(persp.m[3][2], -1.0f), "m4_make_perspective_projection w row");
+
+            // Test look-at helper
+            Matrix4 look = m4_make_look_at(v3f32(0,0,1), v3f32(0,0,0), v3f32(0,1,0));
+            assert(floats_roughly_match(look.m[2][3], -1.0f), "m4_make_look_at translation incorrect");
+        }
     
     // Test Vector2 creation
     Vector2 v2_test1 = v2(1.0f, 2.0f);

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Build the game and run it with Wine
+set -e
+sh build.sh
+wine build/game.exe


### PR DESCRIPTION
## Summary
- extend math library with perspective and rotation helpers
- implement a simple 3D cube flopping puzzle example
- include the new example in the build script
- add Linux helper scripts and docs for installing deps and running
- add integration tests for new math functions
- tidy build script

## Testing
- `sh build.sh -DRUN_TESTS=1`
- `wine build/game.exe` *(fails: cannot create window)*


------
https://chatgpt.com/codex/tasks/task_e_684928efbac0832b9948f1acfddb0f90